### PR TITLE
Update installer.lua

### DIFF
--- a/installer.lua
+++ b/installer.lua
@@ -79,9 +79,13 @@ local function install()
 
     term.setBackgroundColor(colors.black)
     term.setTextColor(colors.white)
+
     term.clear()
 
     term.setCursorPos(1, 1)
+
+    if argStr:lower():find("noconfirm") then return end
+
     write("Finished installation!\nPress any key to close...")
 
     os.pullEventRaw()


### PR DESCRIPTION
Add a noconfirm command line option for bypassing the Press Any Key screen at the end.

I created this PR because I use the installer.lua script in an automated system I have and I want to avoid the user having to perform the interaction at the end of the script.